### PR TITLE
added cfg.reconnect to allow the page in a child frame to reconnect with its parent after a reload

### DIFF
--- a/example/multipage/index.html
+++ b/example/multipage/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>JSChannel example</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="../../src/jschannel.js"></script>
+</head>
+<body>
+  <h2> JSChannel example: <code>reconnect: true</code></h2>
+  <p>
+    Here's a simple example of how to enable a window to "reconnect"
+    to an existing channel. Normally when the child frame gets reloaded,
+    it looses the connection to its parent. 
+  </p>
+  <p>
+    This is a take on how to provide a solution to this issue. 
+    Added the option <code>reconnect: true|false</code> 
+    (defaults to false) to the <code>Channel.build</code> method in the parent frame.
+  </p>
+
+
+  <iframe class="frame" id="childFrame" src="page1.html"></iframe>
+  <div class="log" id="logger">navigated to: ...</div>
+
+  
+  <p>Oh, and you probably need to be on a server, or localhost for this example to run. file:// doesn't quite cut it.</p>
+  
+  <script>
+    var frameDoc = document.getElementById("childFrame").contentWindow,
+      logger = document.getElementById("logger");
+    
+    var chan = Channel.build({
+      debugOutput: true,
+      window: frameDoc,
+      origin: "*",
+      scope: "testScope",
+      reconnect: true
+    });
+
+    chan.bind("navigate", function(trans, s) {
+      console.log('navigate: ', s);
+      logger.innerHTML = "navigated to: " + s.url;
+    });
+    
+    chan.bind("notify", function(t, s) { 
+      console.log("got notification: ", s); 
+    });
+
+    // invoke the function on our child which will cause him to send us a notification 
+    chan.call({method: "sendNotification", success: function() { } });
+
+  </script>
+</body>
+</html>

--- a/example/multipage/page1.html
+++ b/example/multipage/page1.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>JSChannel example: page 1</title>
+    <script src="../../src/jschannel.js"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Page 1</h1>
+    <a href="page2.html">page 2 &rarr;</a>
+
+    <script>
+        var chan = Channel.build({
+            window: window.parent, 
+            origin: "*", 
+            scope: "testScope"
+        });
+
+        chan.notify({
+            method: "navigate",
+            params: {
+                url:document.URL
+            }
+        })
+
+        chan.bind("sendNotification", function(trans, s) {
+            chan.notify({method: "notify", params: "Hi, I'm page 1 ..." });
+        });
+
+    </script>
+</body>
+</html>

--- a/example/multipage/page2.html
+++ b/example/multipage/page2.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>JSChannel example: page 2</title>
+    <script src="../../src/jschannel.js"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Page 2</h1>
+    <a href="page1.html">&larr; page 1</a>
+
+    <script>
+        var chan = Channel.build({
+            window: window.parent, 
+            origin: "*", 
+            scope: "testScope"
+        });
+
+        chan.notify({
+            method: "navigate",
+            params: {
+                url:document.URL
+            }
+        })
+
+        chan.bind("sendNotification", function(trans, s) {
+            chan.notify({method: "notify", params: "Hi, I'm page 2 ..." });
+        });
+
+    </script>
+</body>
+</html>

--- a/example/multipage/style.css
+++ b/example/multipage/style.css
@@ -1,0 +1,22 @@
+body {
+	line-height:1.2;
+}
+h1 {
+	margin:0;
+	padding:0;
+	font-size:1.2em
+}
+.log {
+	background:#ffc;
+	border:1px solid #eeb;
+	padding:0.1em;
+	color:#660;
+}
+
+a {
+	text-decoration:none;
+	color:#33c;
+	display:block;
+}
+a:visited {color:#66C;}
+a:hover {color:#E66}


### PR DESCRIPTION
Hi, I noticed that a channel looses its connection if the page in the child frame is reloaded. 

Needed to be able to "reconnect" with the parent again after navigating inside the iframe, so here's a take on that functionality. A demo can be found under `example/multipage/`. 

Would be great to get some input on this functionality... There's probably a safer and better way to do it. (On that note, the real use case does not use `origin: "*"`)
