### PR TITLE
if Prototype is loaded, remove its Array.toJSON 

### DIFF
--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -233,6 +233,14 @@
             if (!window.JSON || !window.JSON.stringify || ! window.JSON.parse) {
                 throw("jschannel cannot run this browser, no JSON parsing/serialization");
             }
+            if (window.Prototype) {
+                // Some versions of Prototype ship with a broken Array.toJSON
+                // which flattens arrays into strings! Since we have a working
+                // JSON.stringify we can safely remove it.
+                // See: http://stackoverflow.com/questions/710586/json-stringify-bizarreness
+                console.log("removing Prototype's faulty Array.toJSON")
+                delete Array.prototype.toJSON;
+            }
 
             /* basic argument validation */
             if (typeof cfg != 'object') throw("Channel build invoked without a proper object argument");

--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -238,8 +238,15 @@
                 // which flattens arrays into strings! Since we have a working
                 // JSON.stringify we can safely remove it.
                 // See: http://stackoverflow.com/questions/710586/json-stringify-bizarreness
-                console.log("removing Prototype's faulty Array.toJSON")
-                delete Array.prototype.toJSON;
+                console.log("patching Prototype's faulty Array.toJSON")
+                var stringify = window.JSON.stringify;
+                window.JSON.stringify = function(value) {
+                    var _array_tojson = Array.prototype.toJSON;
+                    delete Array.prototype.toJSON;
+                    var r = stringify(value);
+                    Array.prototype.toJSON = _array_tojson;
+                    return r;
+                }
             }
 
             /* basic argument validation */


### PR DESCRIPTION
This is a corner case given Prototype isn't used all that often anymore, but it was a particularly nasty one to track down. It would be nice to save other people the trouble.
