### PR TITLE
Enable connection to pdf.js environments

### DIFF
--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -253,6 +253,8 @@
                 else if (null !== (oMatch = cfg.origin.match(/^https?:\/\/(?:[-a-zA-Z0-9_\.])+(?::\d+)?/))) {
                     cfg.origin = oMatch[0].toLowerCase();
                     validOrigin = true;
+                } else if (cfg.origin == "resource://pdf.js") {
+                    validOrigin = true
                 }
             }
 


### PR DESCRIPTION
Allows connection to the "resource://pdf.js" origin, which is required for talking to PDF.js.
Fixes #20.
