### PR TITLE
Enable loading via AMD / require.js

### DIFF
--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -618,3 +618,10 @@
         }
     };
 })();
+
+//enable loading via AMD
+if (typeof define === 'function' && define.amd) {
+    define(function() {
+        return Channel;
+    });
+}


### PR DESCRIPTION
When loaded as an AMD module, the global-scoped object (window.Channel) is still created.  This makes sure that it will not interfere with existing pages using jschannel.
