### PR TITLE
Do not check null for recursive data structures

### DIFF
--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -560,7 +560,7 @@
                                     callbacks[np] = obj[k];
                                     callbackNames.push(np);
                                     delete obj[k];
-                                } else if (typeof obj[k] === 'object') {
+                                } else if (typeof obj[k] === 'object' && obj[k] !== null) {
                                     pruneFunctions(np, obj[k]);
                                 }
                             }


### PR DESCRIPTION
If a param has more than one `null` anywhere in it, the call will fail, falsely identifying
as a recursive data structure, because in JS, `typeof null === 'object'`
