### PR TITLE
Bower Registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "jschannel",
+  "version": "0.0.1",
+  "homepage": "http://mozilla.github.io/jschannel/docs/",
+  "authors": ["Mozilla"],
+  "description": "A JavaScript library which implements fancy IPC semantics on top of postMessage.",
+  "main": "src/jschannel.js",
+  "keywords": [
+    "IPC",
+    "JSON-RPC",
+    "RPC",
+    "postMessage"
+  ],
+  "license": "MPL",
+  "ignore": [
+    "**/.*",
+    "docs",
+    "example",
+    "perf"
+  ]
+}


### PR DESCRIPTION
Hi, there!

I've added the package to Bower registry so people can easily `bower install jschannel`. Hope you don't mind.

For now, the registry is pointing to my fork, as it contains the _bower.json_ file, but as soon as this pull request gets merged, I'll change it to point to your repository.

Thanks for the great library ;)
