### PR TITLE
#29 add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "jschannel",
+  "version": "1.0.0",
+  "description": "A JavaScript library which implements fancy IPC semantics on top of postMessage.",
+  "main": "src/jschannel.js",
+  "directories": {
+    "doc": "docs",
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla/jschannel.git"
+  },
+  "author": "",
+  "license": "MPL-1.1",
+  "bugs": {
+    "url": "https://github.com/mozilla/jschannel/issues"
+  },
+  "homepage": "https://github.com/mozilla/jschannel#readme"
+}

--- a/src/jschannel.js
+++ b/src/jschannel.js
@@ -218,7 +218,7 @@
      *                the onReady function will be passed a single argument which is
      *                the channel object that was returned from build().
      */
-    return {
+    var _channel = {
         build: function(cfg) {
             var debug = function(m) {
                 if (cfg.debugOutput && window.console && window.console.log) {
@@ -617,4 +617,19 @@
             return obj;
         }
     };
+
+    if (typeof exports !== 'undefined') {
+        if (typeof module !== 'undefined' && module.exports) {
+            exports = module.exports = _channel;
+        }
+        exports.Channel = _channel;
+    }
+
+    if (typeof define === 'function' && define.amd) {
+        define('jschannel', [], function() {
+            return _channel;
+        });
+    }
+
+    return _channel;
 })();


### PR DESCRIPTION
Added _package.json_ and added support of _CommonJs_ and _AMD_ modules (`module.exports` and `define('jschannel', ...`)

Currently you may test installation using command:

`npm install git://github.com/CourseTalk/jschannel.git`

After publishing to npm command will looks like:

`npm install jschannel`
